### PR TITLE
Fix project name in build settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ resolvers ++= List(
 )
 
 lazy val buildSettings = Seq(
-  name := """fair-share""",
   version := "1.0-SNAPSHOT",
   scalaVersion := "2.11.8"
 )
@@ -64,6 +63,10 @@ cancelable in Global := true
 
 lazy val root = project.in(file("."))
   .aggregate(backend, frontend)
+  .settings(
+    name := "fair-share"
+  )
+  .settings(buildSettings)
 
 lazy val backend = project.in(file("backend"))
   .settings(buildSettings)


### PR DESCRIPTION
Because of the change in build name settings wasn't applied, so project's name was 'root' while should be 'fair-share'.
